### PR TITLE
feat: add Slog() method to expose underlying *slog.Logger

### DIFF
--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -155,6 +155,13 @@ func (l *Logger) Error(ctx context.Context, msg string, err error, attrs ...slog
 	l.log(ctx, slog.LevelError, msg, allArgs...)
 }
 
+// Slog returns the underlying *slog.Logger.
+// This is useful for integrating with libraries that accept a standard *slog.Logger,
+// such as watermill.NewSlogLogger().
+func (l *Logger) Slog() *slog.Logger {
+	return l.logger
+}
+
 // With returns a new Logger that includes the given attributes in all log entries.
 // This is useful for creating service-specific or component-specific loggers
 // that always include certain contextual information.

--- a/logging/slog_logger_test.go
+++ b/logging/slog_logger_test.go
@@ -267,6 +267,64 @@ func TestLogger_With(t *testing.T) {
 	validateJSONOutput(t, output, expectedFields)
 }
 
+func TestLogger_Slog(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, err := logging.New(
+		logging.WithWriter(&buf),
+		logging.WithLevel(slog.LevelInfo),
+		logging.WithFormat(logging.FormatJSON),
+	)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	slogLogger := logger.Slog()
+	if slogLogger == nil {
+		t.Fatal("Slog() returned nil")
+	}
+
+	// Verify the returned *slog.Logger writes to the same writer
+	slogLogger.Info("slog direct message", "key", "value")
+
+	output := buf.String()
+	expectedFields := map[string]any{
+		"level": "INFO",
+		"msg":   "slog direct message",
+		"key":   "value",
+	}
+	validateJSONOutput(t, output, expectedFields)
+}
+
+func TestLogger_Slog_WithAttrs(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, err := logging.New(
+		logging.WithWriter(&buf),
+		logging.WithLevel(slog.LevelInfo),
+		logging.WithFormat(logging.FormatJSON),
+	)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	// Slog() on a Logger created with With() should preserve attributes
+	childLogger := logger.With(slog.String("service", "test-service"))
+	slogLogger := childLogger.Slog()
+
+	slogLogger.Info("child slog message")
+
+	output := buf.String()
+	expectedFields := map[string]any{
+		"level":   "INFO",
+		"msg":     "child slog message",
+		"service": "test-service",
+	}
+	validateJSONOutput(t, output, expectedFields)
+}
+
 func TestLogger_ComplexScenario(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Add a `Slog()` method to `Logger` that returns the underlying `*slog.Logger`. This enables integration with libraries that accept a standard `*slog.Logger`, such as Watermill's `watermill.NewSlogLogger()`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #3

## Changes Made

- Added `Slog()` method to `Logger` struct in `slog_logger.go`
- Added `TestLogger_Slog` test verifying the returned logger writes to the same writer
- Added `TestLogger_Slog_WithAttrs` test verifying attributes are preserved via `With()`

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes