### PR TITLE
fix: resolve slog.LogValuer from error chain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/pannpers/go-logging
 
 go 1.25
 
+toolchain go1.25.7
+
 require (
 	connectrpc.com/connect v1.16.0
 	go.opentelemetry.io/otel/trace v1.39.0

--- a/logging/slog_logger.go
+++ b/logging/slog_logger.go
@@ -50,6 +50,7 @@ package logging
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -134,7 +135,8 @@ func (l *Logger) Warn(ctx context.Context, msg string, attrs ...slog.Attr) {
 
 // Error logs an error-level message with an error object and optional attributes.
 // The error object will be automatically added as an "error" attribute.
-// If the error implements slog.LogValue, its custom representation will be used.
+// If any error in the chain implements slog.LogValuer, its structured
+// representation will be used instead of the plain error string.
 //
 // The message will include any attributes stored in the context via SetAttrs,
 // OpenTelemetry trace information if available, the error attribute, and the provided attributes.
@@ -146,7 +148,14 @@ func (l *Logger) Warn(ctx context.Context, msg string, attrs ...slog.Attr) {
 //		slog.Int("port", 5432),
 //	)
 func (l *Logger) Error(ctx context.Context, msg string, err error, attrs ...slog.Attr) {
-	errorAttr := slog.Any("error", err)
+	var errorAttr slog.Attr
+
+	var lv slog.LogValuer
+	if errors.As(err, &lv) {
+		errorAttr = slog.Any("error", lv)
+	} else {
+		errorAttr = slog.Any("error", err)
+	}
 
 	allArgs := make([]slog.Attr, 0, len(attrs)+1)
 	allArgs = append(allArgs, errorAttr) // Error attribute first for better readability

--- a/logging/slog_logger_test.go
+++ b/logging/slog_logger_test.go
@@ -179,6 +179,68 @@ func TestLogger_Error(t *testing.T) {
 	validateJSONOutput(t, output, expectedFields)
 }
 
+func TestLogger_Error_WrappedLogValuer(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, err := logging.New(
+		logging.WithWriter(&buf),
+		logging.WithLevel(slog.LevelError),
+		logging.WithFormat(logging.FormatJSON),
+	)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	// Wrap a LogValuer error with fmt.Errorf — simulating the real-world scenario
+	// where structured error attributes are lost because *fmt.wrapError does not
+	// implement slog.LogValuer.
+	inner := &testError{
+		Message: "not found",
+		Code:    "404",
+	}
+	wrapped := fmt.Errorf("service call failed: %w", inner)
+
+	logger.Error(context.Background(), "request failed", wrapped)
+
+	output := buf.String()
+	expectedFields := map[string]any{
+		"level": "ERROR",
+		"msg":   "request failed",
+		"error": map[string]any{
+			"message": "not found",
+			"code":    "404",
+		},
+	}
+	validateJSONOutput(t, output, expectedFields)
+}
+
+func TestLogger_Error_PlainError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger, err := logging.New(
+		logging.WithWriter(&buf),
+		logging.WithLevel(slog.LevelError),
+		logging.WithFormat(logging.FormatJSON),
+	)
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+
+	// Plain error without LogValuer should still log as string
+	plainErr := errors.New("something went wrong")
+	logger.Error(context.Background(), "plain error", plainErr)
+
+	output := buf.String()
+	expectedFields := map[string]any{
+		"level": "ERROR",
+		"msg":   "plain error",
+		"error": "something went wrong",
+	}
+	validateJSONOutput(t, output, expectedFields)
+}
+
 func TestLogger_WithTraceContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Use `errors.As` in `Logger.Error()` to walk the error chain and resolve `slog.LogValuer` implementations, so structured attributes survive `fmt.Errorf` wrapping
- Add tests for wrapped LogValuer errors and plain errors
- Pin Go toolchain to 1.25.7 via `go.mod` directive

close: #5

## Test plan

- [x] `TestLogger_Error` — direct LogValuer error (existing, still passes)
- [x] `TestLogger_Error_WrappedLogValuer` — wrapped LogValuer preserves structured output
- [x] `TestLogger_Error_PlainError` — plain error still logs as string
- [x] All 20 tests pass